### PR TITLE
fix(ui-ux): fix the dex poolpairid page 

### DIFF
--- a/src/pages/dex/[poolpairId]/_components/PoolPairDetailsBar.tsx
+++ b/src/pages/dex/[poolpairId]/_components/PoolPairDetailsBar.tsx
@@ -34,7 +34,7 @@ export function PoolPairDetailsBar(props: {
             className="font-medium md:text-xl"
             prefix="$"
             value={getTokenPrice(
-              props.poolpair.tokenB.displaySymbol,
+              props.poolpair.tokenB.symbol,
               new BigNumber(props.poolpair.priceRatio.ba)
             ).toFixed(2, BigNumber.ROUND_HALF_UP)}
           />


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
This PR fixes the issue where csETH-dETH page is not showing the value
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/57183851/226304283-9738a27a-dbdc-4c8c-8b13-426e5bafa26e.png">

https://defiscan.live/dex/csETH-dETH

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Sample Links & Screenshots:

<!--
(Optional) Provide a link to changes made using Netlify Preview deployment.
-->

Link:

<details>
<summary>Desktop Screenshot</summary>

<!-- Image has to be between break lines -->

</details>
<details>
<summary>Mobile Screenshot</summary>

<!-- Image has to be between break lines -->

</details>

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] Tested on multiple web browsers
- [ ] Tested responsiveness (e.g, iPhone, iPad, Desktop)
- [ ] No console errors
- [ ] Unit tests\*
- [ ] Added e2e tests\*

<!--
* If applicable
-->
