### PR TITLE
fix(token): increase listToken limit to get all burned token

### DIFF
--- a/src/pages/governance/create/index.page.tsx
+++ b/src/pages/governance/create/index.page.tsx
@@ -18,6 +18,7 @@ import {
   isValidOCGGithubUrl,
   isValidOCGRedditUrl,
 } from "utils/commons/LinkValidator";
+import BigNumber from "bignumber.js";
 import { ProposalDisplayName } from "../_components/ProposalCard";
 import { ReviewProposal } from "../_components/ReviewProposal";
 import { TextAreaComponent } from "../_components/TextAreaComponent";
@@ -301,10 +302,11 @@ export default function CreateProposalPage() {
                         onChange={(value) => {
                           const re = /^\d*\.?\d*$/;
                           if (value === "" || re.test(value.toString())) {
-                            if (value > maxCycle) {
+                            const _value = new BigNumber(value);
+                            if (_value.isGreaterThan(maxCycle)) {
                               return setCycle(maxCycle);
                             }
-                            if (value < minCycle) {
+                            if (_value.isLessThan(minCycle)) {
                               return setCycle(minCycle);
                             }
                             setCycle(value as number);

--- a/src/pages/proof-of-backing/index.page.tsx
+++ b/src/pages/proof-of-backing/index.page.tsx
@@ -53,7 +53,7 @@ export async function getServerSideProps(
   const api = getWhaleApiClient(context);
   const tokenList = await getAllTokens(api);
   const burntTokenList = await api.address
-    .listToken("8defichainBurnAddressXXXXXXXdRQkSm")
+    .listToken("8defichainBurnAddressXXXXXXXdRQkSm", 200)
     .catch(() => {});
   const result: TokenWithBacking[] = [];
   TOKEN_BACKED.forEach((token) => {

--- a/src/pages/tokens/[id].page.tsx
+++ b/src/pages/tokens/[id].page.tsx
@@ -38,7 +38,7 @@ export default function TokenIdPage(
 
   useEffect(() => {
     api.address
-      .listToken("8defichainBurnAddressXXXXXXXdRQkSm")
+      .listToken("8defichainBurnAddressXXXXXXXdRQkSm", 200)
       .then((data) => {
         const burntToken = data.find(
           (token) => token.symbol === props.token.symbol


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- As titled, since burn address has more than the default listToken size, i.e.: 30, so we increase the query size

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Sample Links & Screenshots:

<!--
(Optional) Provide a link to changes made using Netlify Preview deployment.
-->

Link:

<details>
<summary>Desktop Screenshot</summary>

<!-- Image has to be between break lines -->

</details>
<details>
<summary>Mobile Screenshot</summary>

<!-- Image has to be between break lines -->

</details>

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [x] Read your code changes at least once
- [ ] Tested on multiple web browsers
- [x] Tested responsiveness (e.g, iPhone, iPad, Desktop)
- [x] No console errors
- [ ] Unit tests\*
- [ ] Added e2e tests\*

<!--
* If applicable
-->
