### PR TITLE
chore(ui-ux): add non trade chip for poolpairs table and cards for burn2

### DIFF
--- a/src/pages/dex/_components/NonTradeChip.tsx
+++ b/src/pages/dex/_components/NonTradeChip.tsx
@@ -1,0 +1,28 @@
+import classNames from "classnames";
+import React from "react";
+
+export function NonTradeChip({
+  wrapperClassName,
+  className,
+}: {
+  wrapperClassName?: string;
+  className?: string;
+}): JSX.Element {
+  return (
+    <div
+      className={classNames(
+        "flex px-2 py-1 bg-red-50 dark:bg-dark-red-50 rounded w-fit h-fit justify-between mb-2",
+        wrapperClassName
+      )}
+    >
+      <span
+        className={classNames(
+          "text-red-600 dark:text-dark-red-600 font-medium text-[10px] leading-3 tracking-[0.015em]",
+          className
+        )}
+      >
+        NON-TRADE PAIR
+      </span>
+    </div>
+  );
+}

--- a/src/pages/dex/_components/PoolPairsCards.tsx
+++ b/src/pages/dex/_components/PoolPairsCards.tsx
@@ -9,6 +9,7 @@ import { APRInfo } from "./APRInfo";
 import { SortData, SortKeys } from "./PoolPairsTable";
 import { TotalLiquidityInfo } from "./TotalLiquidityInfo";
 import { usePoolPairPrices } from "../hooks/CalculatePoolPairPrices";
+import { NonTradeChip } from "./NonTradeChip";
 
 const sortTypes = [
   {
@@ -136,6 +137,10 @@ export function PoolPairsCard({
         }`}
       >
         <div className="font-medium text-gray-900">
+          {(poolPair.tokenB.displaySymbol.includes("BURN2") ||
+            poolPair.tokenA.displaySymbol.includes("BURN2")) && (
+            <NonTradeChip />
+          )}
           <PoolPairSymbolLocal
             tokenA={poolPair.tokenA}
             tokenB={poolPair.tokenB}

--- a/src/pages/dex/_components/PoolPairsTable.tsx
+++ b/src/pages/dex/_components/PoolPairsTable.tsx
@@ -9,6 +9,7 @@ import BigNumber from "bignumber.js";
 import { APRInfo } from "./APRInfo";
 import { TotalLiquidityInfo } from "./TotalLiquidityInfo";
 import { usePoolPairPrices } from "../hooks/CalculatePoolPairPrices";
+import { NonTradeChip } from "./NonTradeChip";
 
 export enum SortKeys {
   VOLUME = "volume",
@@ -160,6 +161,8 @@ function PoolPairRow({
   return (
     <OverflowTable.Row className="hover:text-primary-500">
       <OverflowTable.Cell className="align-middle">
+        {(poolPair.tokenB.displaySymbol.includes("BURN2") ||
+          poolPair.tokenA.displaySymbol.includes("BURN2")) && <NonTradeChip />}
         <PoolPairSymbolLocal
           tokenA={poolPair.tokenA}
           tokenB={poolPair.tokenB}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
This PR adds a NonTradeChip component to indicate non tradable BURN2 pairs in poolpairs table

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

#### Sample Links & Screenshots:

<!--
(Optional) Provide a link to changes made using Netlify Preview deployment.
-->

Link:

<details>
<summary>Desktop Screenshot</summary>

<!-- Image has to be between break lines -->

</details>
<details>
<summary>Mobile Screenshot</summary>

<!-- Image has to be between break lines -->

</details>

#### Additional comments?:

#### Developer Checklist:

<!--
Merging into the main branch implies your code is ready for production.
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ ] Read your code changes at least once
- [ ] Tested on multiple web browsers
- [ ] Tested responsiveness (e.g, iPhone, iPad, Desktop)
- [ ] No console errors
- [ ] Unit tests\*
- [ ] Added e2e tests\*

<!--
* If applicable
-->
